### PR TITLE
Added missing in-bounds assumptions about the vault

### DIFF
--- a/cvlr_by_example/vault_application/src/certora/macros.rs
+++ b/cvlr_by_example/vault_application/src/certora/macros.rs
@@ -1,6 +1,9 @@
 #[macro_export]
 macro_rules! assume_solvency {
     ($fv_vault:expr) => {{
+        cvlr::prelude::cvlr_assume!(NativeInt::is_u64(&$fv_vault.shares_total));
+        cvlr::prelude::cvlr_assume!(NativeInt::is_u64(&$fv_vault.token_total));
+        
         cvlr::prelude::cvlr_assume!($fv_vault.shares_total <= $fv_vault.token_total);
     }};
 }


### PR DESCRIPTION
We need to ensure that all vault fields are in-bounds.

The vault (from Solana account) is just uninitialized memory for the prover. Then, the verification state FvVault is created from the Solana vault but in-bounds information is not propagated, even if FvVault::from converts a u64 to NativeInt. Unfortunately, this not enough for the prover to know that FvVault fields are actually within u64 bounds.