### PR TITLE
LiveStats feature example

### DIFF
--- a/cvlr_by_example/vault_application/certora/conf/Default.conf
+++ b/cvlr_by_example/vault_application/certora/conf/Default.conf
@@ -19,6 +19,7 @@
         "-solanaRemoveCFGDiamonds true",
         "-solanaTACOptimize 0",
         "-solanaTACMathInt true",
+        "-solanaMinSizeForCalltrace 0"
     ],
     "rule_sanity": "basic",
     "solana_inlining": "../cvlr_inlining.txt",


### PR DESCRIPTION
In this PR we set `solanaMinSizeForCalltrace` to 0, to make sure that all methods in Solana programs are reported in the call trace, and thereforse in the LiveStats panel as well.
* Example run: https://prover.certora.com/output/1324651/afccb25c7710423da4fbbc17a5e126ec?anonymousKey=ce33f00f8f2a14197a853aa3874236e6c5d6ff63
* To reproduce: `cd cvlr_by_example/vault_application/certora/conf` and `certoraSolanaProver Default.conf`
* ![Screenshot 2025-03-31 at 10 34 22](https://github.com/user-attachments/assets/7837dd0b-4e04-4d7a-9e24-b68de90beb81)
