### PR TITLE
Update PROJECT_DIR, SOURCES, and EXECUTABLES paths in build scripts

### DIFF
--- a/cvlr_by_example/first_example/certora_build.py
+++ b/cvlr_by_example/first_example/certora_build.py
@@ -13,9 +13,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 COMMAND = "just build-sbf"
 
 # JSON FIELDS
-PROJECT_DIR = (SCRIPT_DIR).resolve()
-SOURCES = ["src/**/*.rs"]
-EXECUTABLES = "../../target/sbf-solana-solana/release/first_example.so"
+PROJECT_DIR = (SCRIPT_DIR).resolve().parent.resolve().parent.resolve()
+SOURCES = ["cvlr_by_example/first_example/src/**/*.rs"]
+EXECUTABLES = "target/sbf-solana-solana/release/first_example.so"
 VERBOSE = False
 
 

--- a/cvlr_by_example/first_example/certora_build.py
+++ b/cvlr_by_example/first_example/certora_build.py
@@ -13,8 +13,11 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 COMMAND = "just build-sbf"
 
 # JSON FIELDS
+# This example uses Cargo Workspaces (https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html), and the root of the project is two levels up.
 PROJECT_DIR = (SCRIPT_DIR).resolve().parent.resolve().parent.resolve()
+# Relative from PROJECT_DIR. 
 SOURCES = ["cvlr_by_example/first_example/src/**/*.rs"]
+# Relative from PROJECT_DIR. 
 EXECUTABLES = "target/sbf-solana-solana/release/first_example.so"
 VERBOSE = False
 

--- a/cvlr_by_example/vault_application/certora_build.py
+++ b/cvlr_by_example/vault_application/certora_build.py
@@ -13,8 +13,11 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 COMMAND = "just build-sbf"
 
 # JSON FIELDS
+# This example uses Cargo Workspaces (https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html), and the root of the project is two levels up.
 PROJECT_DIR = (SCRIPT_DIR).resolve().parent.resolve().parent.resolve()
+# Relative from PROJECT_DIR. 
 SOURCES = [ "cvlr_by_example/vault_application/src/**/*.rs" ]
+# Relative from PROJECT_DIR. 
 EXECUTABLES = "target/sbf-solana-solana/release/vault_application.so"
 VERBOSE = False
 

--- a/cvlr_by_example/vault_application/certora_build.py
+++ b/cvlr_by_example/vault_application/certora_build.py
@@ -13,9 +13,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 COMMAND = "just build-sbf"
 
 # JSON FIELDS
-PROJECT_DIR = (SCRIPT_DIR).resolve()
-SOURCES = [ "src/**/*.rs" ]
-EXECUTABLES = "../../target/sbf-solana-solana/release/vault_application.so"
+PROJECT_DIR = (SCRIPT_DIR).resolve().parent.resolve().parent.resolve()
+SOURCES = [ "cvlr_by_example/vault_application/src/**/*.rs" ]
+EXECUTABLES = "target/sbf-solana-solana/release/vault_application.so"
 VERBOSE = False
 
 


### PR DESCRIPTION
This PR updates `PROJECT_DIR`, `SOURCES`, and `EXECUTABLES` in the build scripts.
This is to take into account that we use a workspace-based project.
Now we have jump to source for the failing asserts.
Runs:
* First example: https://prover.certora.com/output/1324651/d76df46b3ff843169ac51568400b6f82?anonymousKey=e9aac78a478b5cbcc75c2d1c4998f2d174b5be04
* Vault application: https://prover.certora.com/output/1324651/e57ff172375f49619363f18bdabac360?anonymousKey=6bd7db39eabbc305aed3a888a898b01b884edcb9