### PR TITLE
Fix CI ssh keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
       - run:
           name: Install ReportAnalyzer
           command: |
-            pip3.11 install git+ssh://git@github.com/Certora/ReportAnalysis.git
+            pip3.11 install git+ssh://git@github.com-reportanalysis/Certora/ReportAnalysis.git
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
 
   # This command now accepts a 'package' parameter to specify the CLI version.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,12 @@ commands:
   
   install_report_analyzer:
     steps:
-      - run:
-          name: Fix ssh config
-          command: echo "HostName github.com" >> ~/.ssh/config
       - add_ssh_keys:
           fingerprints:
             - "SHA256:3Suza/qbe+9JJow4Xpsmirb24reG9o5NZFMoVt7MTs0"
+      - run:
+          name: Fix ssh config
+          command: echo "HostName github.com" >> ~/.ssh/config
       - run:
           name: Install ReportAnalyzer
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "52:a3:91:f1:01:ae:82:72:c6:1d:33:0e:af:a4:19:a0"
+            - "SHA256:bXE/cHQMq2ZVFCAOGz/BVqKOCJLyiUUoEBKrhSBHb5s"
       - run:
           name: Install ConfRunnerInfra
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ parameters:
 commands:
   install_conf_runner_infra:
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "52:a3:91:f1:01:ae:82:72:c6:1d:33:0e:af:a4:19:a0"
       - run:
           name: Install ConfRunnerInfra
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ commands:
   
   install_report_analyzer:
     steps:
+      - run:
+          name: Fix ssh config
+          command: echo "HostName github.com" >> ~/.ssh/config
       - add_ssh_keys:
           fingerprints:
             - "SHA256:3Suza/qbe+9JJow4Xpsmirb24reG9o5NZFMoVt7MTs0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ commands:
   
   install_report_analyzer:
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:3Suza/qbe+9JJow4Xpsmirb24reG9o5NZFMoVt7MTs0"
       - run:
           name: Install ReportAnalyzer
           command: |


### PR DESCRIPTION
We were using a personal key to install ConfRunnerInfra and ReportAnalyzer, it was replaced by specific deploy ssh keys.