### PR TITLE
Use just 1.42

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commands:
     steps:
       - run:
           name: Install Just
-          command: cargo install just --locked
+          command: cargo install just --version 1.42.4 --locked
 
   regression:
     steps:


### PR DESCRIPTION
Using just version 1.42 since the latest just version does not support rust 1.79.