### PR TITLE
Home package breaks ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ commands:
           name: Install certora-sbf 
           command: |
             rustup toolchain install 1.86
-            cargo +1.86 install cargo-certora-sbf
+            cargo +1.86 install cargo-certora-sbf --locked
 
   install_certora_platform_tools:
      steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,3 @@ spl-token = { version = "4", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3", features = ["no-entrypoint"] }
 bytemuck = "1.7.2"
 spl-pod = "0.2.5"
-home = "=0.5.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ spl-token = { version = "4", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3", features = ["no-entrypoint"] }
 bytemuck = "1.7.2"
 spl-pod = "0.2.5"
+home = "=0.5.11"


### PR DESCRIPTION
Latest version of `home` package require rust 1.88 and breaks CI.
Locking `home` package to a previous version.