### PR TITLE
CERT-9316 | Stop using GitHub PAT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
       - run:
           name: Install ConfRunnerInfra
           command: |
-            pip3.11 install git+ssh://git@github.com/Certora/ConfRunnerInfra.git
+            pip install git+ssh://git@github.com/Certora/ConfRunnerInfra.git
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
   
   install_report_analyzer:
@@ -52,7 +52,7 @@ commands:
           name: Install ReportAnalyzer
           command: |
             # TODO: change this back to the default branch
-            pip3.11 install git+ssh://git@github.com-reportanalysis/Certora/ReportAnalysis.git@oz/pat
+            pip install git+ssh://git@github.com-reportanalysis/Certora/ReportAnalysis.git@oz/pat
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
 
   # This command now accepts a 'package' parameter to specify the CLI version.
@@ -64,7 +64,7 @@ commands:
     steps:
       - run:
           name: Install Certora CLI Package (<< parameters.package >>)
-          command: pip3.11 install << parameters.package >>
+          command: pip install << parameters.package >>
 
   configure_aws:
     steps:
@@ -117,14 +117,14 @@ commands:
 jobs:
   check-release-sbf:
     docker:
-      - image: &cvt-image public.ecr.aws/certora/cvt-image:2024.10.16-4480-c8870b3
+      - image: &cvt-image public.ecr.aws/certora/cvt-image:2026.01.18-5647-d0d207c
     resource_class: small
     working_directory: ~/repo
     steps:
       - checkout
       - run:
           name: Install Python deps
-          command: pip3.11 install requests semver
+          command: pip install requests semver
       - run:
           name: Check certora-cli releases & trigger SolanaExamples CI
           command: python3.11 .circleci/ReleaseCheckAndTrigger_solana.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@4.0.0
+  secure-repo-access: certora/secure-repo-access@0.0.2
 
 parameters:
   run_nightly_report_analyze:
@@ -50,7 +51,8 @@ commands:
       - run:
           name: Install ReportAnalyzer
           command: |
-            pip3.11 install git+ssh://git@github.com-reportanalysis/Certora/ReportAnalysis.git
+            # TODO: change this back to the default branch
+            pip3.11 install git+ssh://git@github.com-reportanalysis/Certora/ReportAnalysis.git@oz/pat
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
 
   # This command now accepts a 'package' parameter to specify the CLI version.
@@ -192,6 +194,8 @@ jobs:
       - install_certora_sbf
       - install_certora_platform_tools
       - install_just
+      - secure-repo-access/get_token:
+          github_repository: "EVMVerifier"
       - run:
           name: Run nightly report analyzer
           no_output_timeout: 5h 
@@ -248,7 +252,9 @@ workflows:
     when: << pipeline.parameters.run_nightly_report_analyze >>
     jobs:
       - report_analyzer:
-          context: aws_staging
+          context:
+            - aws_staging
+            - secure-repo-access
 
   manual:
     when: << pipeline.parameters.run_workflow_nightly >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ workflows:
       - report_analyzer:
           context:
             - aws_staging
-            - secure-repo-access
+            - secure_repo_access
 
   manual:
     when: << pipeline.parameters.run_workflow_nightly >>


### PR DESCRIPTION
- Using secure-repo-access orb to generate temporary github tokens
- Changed cvt image to the latest image with python 3.11
- Changed pip3.11 to pip